### PR TITLE
Added workflow to commit changes (.R files under R/) made in master to gh-pages

### DIFF
--- a/.github/workflows/Update_ghpages.yml
+++ b/.github/workflows/Update_ghpages.yml
@@ -1,0 +1,25 @@
+name: Commit changes to gh-pages
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - R/**.R
+  pull_request:
+    branches:
+      - master
+    paths:
+      - R/**.R
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1
+      - name: Deploy 
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: gh-pages 
+          folder: R
+          clean: false
+          target-folder: R


### PR DESCRIPTION
Workflow Guide
---
This workflow is triggered on commits which involve changes to the R files contained within the R/ directory for the master branch, may it be from a direct push, or one from a pull request (authored by anyone). These modifications are then brought under the R/ folder on the gh-pages branch (thus keeping the .R files present there up-to-date with the ones on the master branch) with the help of this [action](https://github.com/JamesIves/github-pages-deploy-action).

Apart from such specific changes, a commit might involve other changes as well, in which case too, only the modifications (includes addition of new .R files) made to R files inside the R/ folder will be carry-forwarded to gh-pages, since the deployment is made based on my designated path filter (`paths: - R/**.R`).

Caveats
---
- An important note for future edits: `clean` must be always set to `false` (default is `true`) for our case here, as when set as `true`, it would eradicate everything on the gh-pages branch which are not covered as changes! 
- While adding R files or changing the content in them does count as modifications, deleting them does not, i.e. to say file deletions won't trigger the workflow (not specific to just this though, but for all 'on: push' type events) 
- `folder` and `target-folder` may look the same here, but they are different in the sense that the later requires a full-path specification. For instance, if I were to make this same workflow for carrying over changes from master to dldoc, I would need to specify `folder: R` and `target folder: pkg/directlabels/R` (apart from setting `branch` to `dldoc`). 

@tdhock this is not a work-in-progress, so feel free to merge if it is okay!