### PR TITLE
Use GitHub pages hosted CSS file (Update to last PR) 

### DIFF
--- a/docs/contourplot/plots/environmental.html
+++ b/docs/contourplot/plots/environmental.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - environmental</title>
   </head>

--- a/docs/contourplot/plots/volcano.html
+++ b/docs/contourplot/plots/volcano.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - volcano</title>
   </head>

--- a/docs/contourplot/posfuns/bottom.pieces.html
+++ b/docs/contourplot/posfuns/bottom.pieces.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - bottom.pieces</title>
   </head>

--- a/docs/contourplot/posfuns/bottom.points.html
+++ b/docs/contourplot/posfuns/bottom.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - bottom.points</title>
   </head>

--- a/docs/contourplot/posfuns/top.pieces.html
+++ b/docs/contourplot/posfuns/top.pieces.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.pieces</title>
   </head>

--- a/docs/contourplot/posfuns/top.points.html
+++ b/docs/contourplot/posfuns/top.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.points</title>
   </head>

--- a/docs/densityplot/plots/chemscore.html
+++ b/docs/densityplot/plots/chemscore.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - chemscore</title>
   </head>

--- a/docs/densityplot/plots/iris.html
+++ b/docs/densityplot/plots/iris.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - iris</title>
   </head>

--- a/docs/densityplot/plots/loci.html
+++ b/docs/densityplot/plots/loci.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - loci</title>
   </head>

--- a/docs/densityplot/posfuns/top.bumptwice.html
+++ b/docs/densityplot/posfuns/top.bumptwice.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.bumptwice</title>
   </head>

--- a/docs/densityplot/posfuns/top.bumpup.html
+++ b/docs/densityplot/posfuns/top.bumpup.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.bumpup</title>
   </head>

--- a/docs/densityplot/posfuns/top.points.html
+++ b/docs/densityplot/posfuns/top.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.points</title>
   </head>

--- a/docs/dotplot/plots/vadeaths-lattice.html
+++ b/docs/dotplot/plots/vadeaths-lattice.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - vadeaths-lattice</title>
   </head>

--- a/docs/dotplot/plots/vadeaths.html
+++ b/docs/dotplot/plots/vadeaths.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - vadeaths</title>
   </head>

--- a/docs/dotplot/posfuns/angled.endpoints.html
+++ b/docs/dotplot/posfuns/angled.endpoints.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - angled.endpoints</title>
   </head>

--- a/docs/dotplot/posfuns/top.qp.html
+++ b/docs/dotplot/posfuns/top.qp.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - top.qp</title>
   </head>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-  <link href="../estilo1.css" rel="stylesheet" type="text/css" />
+  <link href="https://tdhock.github.io/directlabels/estilo1.css" rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - home</title>
   </head>
 

--- a/docs/lineplot/plots/bodyweight.html
+++ b/docs/lineplot/plots/bodyweight.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - bodyweight</title>
   </head>

--- a/docs/lineplot/plots/chemqqmathscore.html
+++ b/docs/lineplot/plots/chemqqmathscore.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - chemqqmathscore</title>
   </head>

--- a/docs/lineplot/plots/chemqqmathsex.html
+++ b/docs/lineplot/plots/chemqqmathsex.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - chemqqmathsex</title>
   </head>

--- a/docs/lineplot/plots/lars.html
+++ b/docs/lineplot/plots/lars.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - lars</title>
   </head>

--- a/docs/lineplot/plots/projectionSeconds.html
+++ b/docs/lineplot/plots/projectionSeconds.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - projectionSeconds</title>
   </head>

--- a/docs/lineplot/plots/ridge.html
+++ b/docs/lineplot/plots/ridge.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - ridge</title>
   </head>

--- a/docs/lineplot/plots/sexdeaths.html
+++ b/docs/lineplot/plots/sexdeaths.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - sexdeaths</title>
   </head>

--- a/docs/lineplot/posfuns/angled.boxes.html
+++ b/docs/lineplot/posfuns/angled.boxes.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - angled.boxes</title>
   </head>

--- a/docs/lineplot/posfuns/first.bumpup.html
+++ b/docs/lineplot/posfuns/first.bumpup.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - first.bumpup</title>
   </head>

--- a/docs/lineplot/posfuns/first.points.html
+++ b/docs/lineplot/posfuns/first.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - first.points</title>
   </head>

--- a/docs/lineplot/posfuns/first.polygons.html
+++ b/docs/lineplot/posfuns/first.polygons.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - first.polygons</title>
   </head>

--- a/docs/lineplot/posfuns/first.qp.html
+++ b/docs/lineplot/posfuns/first.qp.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - first.qp</title>
   </head>

--- a/docs/lineplot/posfuns/lasso.labels.html
+++ b/docs/lineplot/posfuns/lasso.labels.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - lasso.labels</title>
   </head>

--- a/docs/lineplot/posfuns/last.bumpup.html
+++ b/docs/lineplot/posfuns/last.bumpup.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - last.bumpup</title>
   </head>

--- a/docs/lineplot/posfuns/last.points.html
+++ b/docs/lineplot/posfuns/last.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - last.points</title>
   </head>

--- a/docs/lineplot/posfuns/last.polygons.html
+++ b/docs/lineplot/posfuns/last.polygons.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - last.polygons</title>
   </head>

--- a/docs/lineplot/posfuns/last.qp.html
+++ b/docs/lineplot/posfuns/last.qp.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - last.qp</title>
   </head>

--- a/docs/lineplot/posfuns/lines2.html
+++ b/docs/lineplot/posfuns/lines2.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - lines2</title>
   </head>

--- a/docs/lineplot/posfuns/maxvar.points.html
+++ b/docs/lineplot/posfuns/maxvar.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - maxvar.points</title>
   </head>

--- a/docs/lineplot/posfuns/maxvar.qp.html
+++ b/docs/lineplot/posfuns/maxvar.qp.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - maxvar.qp</title>
   </head>

--- a/docs/scatterplot/plots/class-manufacturer.html
+++ b/docs/scatterplot/plots/class-manufacturer.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - class-manufacturer</title>
   </head>

--- a/docs/scatterplot/plots/cylinders.html
+++ b/docs/scatterplot/plots/cylinders.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - cylinders</title>
   </head>

--- a/docs/scatterplot/plots/iris.html
+++ b/docs/scatterplot/plots/iris.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - iris</title>
   </head>

--- a/docs/scatterplot/plots/mpg.html
+++ b/docs/scatterplot/plots/mpg.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - mpg</title>
   </head>

--- a/docs/scatterplot/plots/mpglattice.html
+++ b/docs/scatterplot/plots/mpglattice.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - mpglattice</title>
   </head>

--- a/docs/scatterplot/plots/path.html
+++ b/docs/scatterplot/plots/path.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - path</title>
   </head>

--- a/docs/scatterplot/posfuns/ahull.grid.html
+++ b/docs/scatterplot/posfuns/ahull.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - ahull.grid</title>
   </head>

--- a/docs/scatterplot/posfuns/chull.grid.html
+++ b/docs/scatterplot/posfuns/chull.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - chull.grid</title>
   </head>

--- a/docs/scatterplot/posfuns/closest.on.ahull.html
+++ b/docs/scatterplot/posfuns/closest.on.ahull.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - closest.on.ahull</title>
   </head>

--- a/docs/scatterplot/posfuns/closest.on.chull.html
+++ b/docs/scatterplot/posfuns/closest.on.chull.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - closest.on.chull</title>
   </head>

--- a/docs/scatterplot/posfuns/empty.grid.html
+++ b/docs/scatterplot/posfuns/empty.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - empty.grid</title>
   </head>

--- a/docs/scatterplot/posfuns/extreme.grid.html
+++ b/docs/scatterplot/posfuns/extreme.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - extreme.grid</title>
   </head>

--- a/docs/scatterplot/posfuns/perpendicular.grid.html
+++ b/docs/scatterplot/posfuns/perpendicular.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - perpendicular.grid</title>
   </head>

--- a/docs/scatterplot/posfuns/smart.grid.html
+++ b/docs/scatterplot/posfuns/smart.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - smart.grid</title>
   </head>

--- a/docs/templates/head.html
+++ b/docs/templates/head.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - OBJ$pagetitle</title>
   </head>

--- a/docs/templates/index.html
+++ b/docs/templates/index.html
@@ -15,8 +15,11 @@ after installing and loading the directlabels package. To get started,
 execute this R code:</p>
 
 <pre>
-## Required dependencies:
-install.packages(c("directlabels","ggplot2","reshape2","mlmRev","lars","latticeExtra"))
+## Install required dependencies:
+install.packages(c("ggplot2","reshape2","mlmRev","lars","latticeExtra"))
+## Install directlabels:
+install.packages("directlabels")
+## Load it:
 library(directlabels)
 </pre>
 

--- a/docs/utility.function/posfuns/ahull.points.html
+++ b/docs/utility.function/posfuns/ahull.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - ahull.points</title>
   </head>

--- a/docs/utility.function/posfuns/apply.method.html
+++ b/docs/utility.function/posfuns/apply.method.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - apply.method</title>
   </head>

--- a/docs/utility.function/posfuns/big.boxes.html
+++ b/docs/utility.function/posfuns/big.boxes.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - big.boxes</title>
   </head>

--- a/docs/utility.function/posfuns/bumpup.html
+++ b/docs/utility.function/posfuns/bumpup.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - bumpup</title>
   </head>

--- a/docs/utility.function/posfuns/calc.borders.html
+++ b/docs/utility.function/posfuns/calc.borders.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - calc.borders</title>
   </head>

--- a/docs/utility.function/posfuns/calc.boxes.html
+++ b/docs/utility.function/posfuns/calc.boxes.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - calc.boxes</title>
   </head>

--- a/docs/utility.function/posfuns/check.for.columns.html
+++ b/docs/utility.function/posfuns/check.for.columns.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - check.for.columns</title>
   </head>

--- a/docs/utility.function/posfuns/chull.points.html
+++ b/docs/utility.function/posfuns/chull.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - chull.points</title>
   </head>

--- a/docs/utility.function/posfuns/default.ahull.html
+++ b/docs/utility.function/posfuns/default.ahull.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - default.ahull</title>
   </head>

--- a/docs/utility.function/posfuns/dens.gradient.html
+++ b/docs/utility.function/posfuns/dens.gradient.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dens.gradient</title>
   </head>

--- a/docs/utility.function/posfuns/dl.combine.html
+++ b/docs/utility.function/posfuns/dl.combine.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dl.combine</title>
   </head>

--- a/docs/utility.function/posfuns/dl.jitter.html
+++ b/docs/utility.function/posfuns/dl.jitter.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dl.jitter</title>
   </head>

--- a/docs/utility.function/posfuns/dl.move.html
+++ b/docs/utility.function/posfuns/dl.move.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dl.move</title>
   </head>

--- a/docs/utility.function/posfuns/dl.summarize.html
+++ b/docs/utility.function/posfuns/dl.summarize.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dl.summarize</title>
   </head>

--- a/docs/utility.function/posfuns/dl.trans.html
+++ b/docs/utility.function/posfuns/dl.trans.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - dl.trans</title>
   </head>

--- a/docs/utility.function/posfuns/draw.polygons.html
+++ b/docs/utility.function/posfuns/draw.polygons.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - draw.polygons</title>
   </head>

--- a/docs/utility.function/posfuns/draw.rects.html
+++ b/docs/utility.function/posfuns/draw.rects.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - draw.rects</title>
   </head>

--- a/docs/utility.function/posfuns/edges.to.outside.html
+++ b/docs/utility.function/posfuns/edges.to.outside.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - edges.to.outside</title>
   </head>

--- a/docs/utility.function/posfuns/empty.grid.html
+++ b/docs/utility.function/posfuns/empty.grid.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - empty.grid</title>
   </head>

--- a/docs/utility.function/posfuns/enlarge.box.html
+++ b/docs/utility.function/posfuns/enlarge.box.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - enlarge.box</title>
   </head>

--- a/docs/utility.function/posfuns/extreme.points.html
+++ b/docs/utility.function/posfuns/extreme.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - extreme.points</title>
   </head>

--- a/docs/utility.function/posfuns/far.from.others.borders.html
+++ b/docs/utility.function/posfuns/far.from.others.borders.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - far.from.others.borders</title>
   </head>

--- a/docs/utility.function/posfuns/follow.points.html
+++ b/docs/utility.function/posfuns/follow.points.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - follow.points</title>
   </head>

--- a/docs/utility.function/posfuns/gapply.fun.html
+++ b/docs/utility.function/posfuns/gapply.fun.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - gapply.fun</title>
   </head>

--- a/docs/utility.function/posfuns/gapply.html
+++ b/docs/utility.function/posfuns/gapply.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - gapply</title>
   </head>

--- a/docs/utility.function/posfuns/get.means.html
+++ b/docs/utility.function/posfuns/get.means.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - get.means</title>
   </head>

--- a/docs/utility.function/posfuns/ignore.na.html
+++ b/docs/utility.function/posfuns/ignore.na.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - ignore.na</title>
   </head>

--- a/docs/utility.function/posfuns/in1box.html
+++ b/docs/utility.function/posfuns/in1box.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - in1box</title>
   </head>

--- a/docs/utility.function/posfuns/in1which.html
+++ b/docs/utility.function/posfuns/in1which.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - in1which</title>
   </head>

--- a/docs/utility.function/posfuns/inside.html
+++ b/docs/utility.function/posfuns/inside.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - inside</title>
   </head>

--- a/docs/utility.function/posfuns/label.endpoints.html
+++ b/docs/utility.function/posfuns/label.endpoints.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - label.endpoints</title>
   </head>

--- a/docs/utility.function/posfuns/label.pieces.html
+++ b/docs/utility.function/posfuns/label.pieces.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - label.pieces</title>
   </head>

--- a/docs/utility.function/posfuns/lasso.labels.html
+++ b/docs/utility.function/posfuns/lasso.labels.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - lasso.labels</title>
   </head>

--- a/docs/utility.function/posfuns/make.tiebreaker.html
+++ b/docs/utility.function/posfuns/make.tiebreaker.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - make.tiebreaker</title>
   </head>

--- a/docs/utility.function/posfuns/midrange.html
+++ b/docs/utility.function/posfuns/midrange.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - midrange</title>
   </head>

--- a/docs/utility.function/posfuns/only.unique.vals.html
+++ b/docs/utility.function/posfuns/only.unique.vals.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - only.unique.vals</title>
   </head>

--- a/docs/utility.function/posfuns/outside.ahull.html
+++ b/docs/utility.function/posfuns/outside.ahull.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - outside.ahull</title>
   </head>

--- a/docs/utility.function/posfuns/outside.chull.html
+++ b/docs/utility.function/posfuns/outside.chull.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - outside.chull</title>
   </head>

--- a/docs/utility.function/posfuns/perpendicular.lines.html
+++ b/docs/utility.function/posfuns/perpendicular.lines.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - perpendicular.lines</title>
   </head>

--- a/docs/utility.function/posfuns/polygon.method.html
+++ b/docs/utility.function/posfuns/polygon.method.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - polygon.method</title>
   </head>

--- a/docs/utility.function/posfuns/project.onto.segments.html
+++ b/docs/utility.function/posfuns/project.onto.segments.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - project.onto.segments</title>
   </head>

--- a/docs/utility.function/posfuns/qp.labels.html
+++ b/docs/utility.function/posfuns/qp.labels.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - qp.labels</title>
   </head>

--- a/docs/utility.function/posfuns/reduce.cex.lr.html
+++ b/docs/utility.function/posfuns/reduce.cex.lr.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - reduce.cex.lr</title>
   </head>

--- a/docs/utility.function/posfuns/static.labels.html
+++ b/docs/utility.function/posfuns/static.labels.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - static.labels</title>
   </head>

--- a/docs/utility.function/posfuns/vertical.qp.html
+++ b/docs/utility.function/posfuns/vertical.qp.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - vertical.qp</title>
   </head>

--- a/docs/utility.function/posfuns/visualcenter.html
+++ b/docs/utility.function/posfuns/visualcenter.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - visualcenter</title>
   </head>

--- a/docs/utility.function/posfuns/xlimits.html
+++ b/docs/utility.function/posfuns/xlimits.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - xlimits</title>
   </head>

--- a/docs/utility.function/posfuns/ylimits.html
+++ b/docs/utility.function/posfuns/ylimits.html
@@ -6,7 +6,7 @@
   <head>
 	<meta http-equiv="Content-Type" content="text/html;
 	charset=UTF-8" />
-	<link href="../../../estilo1.css"
+	<link href="https://tdhock.github.io/directlabels/estilo1.css"
 	rel="stylesheet" type="text/css" />
 	<title>directlabels documentation - ylimits</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -54,27 +54,27 @@ legends? Why not just add direct labels by hand?</a></li>
 <li><a href="http://stackoverflow.com/search?q=directlabels">Before
 emailing me, please search and post on stackoverflow</a>.</li>
 <li>How to avoid overlapping labels? Use a Positioning Method
-with <a href="http://directlabels.r-forge.r-project.org/docs/utility.function/posfuns/calc.boxes.html">calc.boxes</a>
+with <a href="https://tdhock.github.io/directlabels/docs/utility.function/posfuns/calc.boxes.html">calc.boxes</a>
 to compute the label bounding box. For
-example, <a href="http://directlabels.r-forge.r-project.org/docs/scatterplot/posfuns/smart.grid.html">smart.grid</a>
+example, <a href="https://tdhock.github.io/directlabels/docs/scatterplot/posfuns/smart.grid.html">smart.grid</a>
 for scatterplots
-and <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/posfuns/last.polygons.html">last.polygons</a>
-or <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/posfuns/last.qp.html">last.qp</a>
+and <a href="https://tdhock.github.io/directlabels/docs/lineplot/posfuns/last.polygons.html">last.polygons</a>
+or <a href="https://tdhock.github.io/directlabels/docs/lineplot/posfuns/last.qp.html">last.qp</a>
 for lineplots.</li>
 <li>Can I increase text size? Yes, but do it before calling
 Positioning Methods that calculate the label bounding
 box: <tt>direct.label(p, list(cex=2, "last.qp"))</tt> for a lineplot <tt>p</tt>.</li>
 <li>Why are some labels small when using lineplot labeling methods
-like <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/posfuns/last.polygons.html">last.polygons</a>?
+like <a href="https://tdhock.github.io/directlabels/docs/lineplot/posfuns/last.polygons.html">last.polygons</a>?
 Because the labels are automatically resized to fit in the plotting
 area. To increase the text size you can increase the x axis limits as in
-the <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/plots/lars.html">lars</a>
-and <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/plots/ridge.html">ridge</a>
+the <a href="https://tdhock.github.io/directlabels/docs/lineplot/plots/lars.html">lars</a>
+and <a href="https://tdhock.github.io/directlabels/docs/lineplot/plots/ridge.html">ridge</a>
 examples.</li>
 <li>How to adjust all labels left or right?  For example you can
 use <tt>direct.label(p, list(dl.trans(x=x+0.1), "last.qp"))</tt> to
 move labels to the right 0.1cm and then
-apply <a href="http://directlabels.r-forge.r-project.org/docs/lineplot/posfuns/last.qp.html">last.qp</a>
+apply <a href="https://tdhock.github.io/directlabels/docs/lineplot/posfuns/last.qp.html">last.qp</a>
 for a lineplot <tt>p</tt>.</li>
 <li>How
 about <tt>fontface</tt>, <tt>fontfamily</tt>, <tt>rot</tt>, <tt>alpha</tt>
@@ -102,7 +102,7 @@ directlabels package introduces the concept of the Positioning Method,
 which is a list that specifies how to transform the data points into
 labels. For example, with the scatterplot above, the default
 Positioning Method is
-<a href="http://directlabels.r-forge.r-project.org/docs/scatterplot/posfuns/smart.grid.html">smart.grid</a>,
+<a href="https://tdhock.github.io/directlabels/docs/scatterplot/posfuns/smart.grid.html">smart.grid</a>,
 which places each label close to the center of the corresponding point
 cloud. The following diagram shows how the data to plot is converted
 to standard form column names and positions in centimeters before the
@@ -119,14 +119,14 @@ Petal.Length Sepal.Length Species
          1.5          4.6  setosa
          1.4          5.0  setosa
          1.7          5.4  setosa
-         ...          ...    ...  
+         ...          ...    ...
 </pre>
 </td>
 <td>
 <pre>
  convert to
  standard form (cm)
----------------------&gt;  
+---------------------&gt;
  direct.label.trellis
  and
  drawDetails.dlgrob
@@ -141,7 +141,7 @@ Petal.Length Sepal.Length Species
 2.269632 1.986922 setosa
 2.021041 3.426721 setosa
 2.766813 4.866519 setosa
-    ...      ...    ...  
+    ...      ...    ...
 </pre>
 </td>
 <td>
@@ -149,7 +149,7 @@ Petal.Length Sepal.Length Species
  calculate label
  positions with
  Positioning Method
----------------------&gt;  
+---------------------&gt;
  smart.grid
 </pre>
 </td>
@@ -199,7 +199,7 @@ using lattice or ggplot2.</p>
 <p>
 <a href="2012-03-29-HOCKING-directlabels-semin-r.pdf">Recent
 advances in direct labeled graphics</a>
-[<a href="http://r-forge.r-project.org/scm/viewvc.php/tex/2012-semin-r/?root=directlabels">source</a>]. Invited talk
+[<a href="https://github.com/tdhock/directlabels/tree/gh-pages/tex/2012-semin-r">source</a>]. Invited talk
 for semin-r, the Paris R user group (2012).
 </p>
 
@@ -209,10 +209,10 @@ labels to
 plots</a>, <a href="http://www.warwick.ac.uk/statsdept/user-2011/">Best
 Student Poster at useR 2011</a>, attempts to motivate the package and
 explain how it works
-[<a href="http://r-forge.r-project.org/scm/viewvc.php/tex/useR-2011/?root=directlabels">source</a>]. Notably,
+[<a href="https://github.com/tdhock/directlabels/tree/gh-pages/tex/useR-2011">source</a>]. Notably,
 the "Optimal Labels" section is basically the only documentation of
 how to implement
-the <a href="http://directlabels.r-forge.r-project.org/docs/utility.function/posfuns/qp.labels.html">qp.labels</a>
+the <a href="https://tdhock.github.io/directlabels/docs/utility.function/posfuns/qp.labels.html">qp.labels</a>
 Positioning Method. The details of the "Modular package design"
 section have changed in version 2.0. Rather than
 calling <tt>label.positions</tt> the first time the plot
@@ -244,15 +244,15 @@ on the R Graphical Manual</a>.</p>
 
 
 <p>Return to
-the <a href="http://r-forge.r-project.org/projects/directlabels/"><strong>project
-summary page</strong></a>. </p>
+the <a href="https://github.com/tdhock/directlabels"><strong>GitHub
+repository</strong></a>. </p>
 
 <center>
 <table>
 <tr>
 
 <td>Please send email to <a
-href="http://cbio.ensmp.fr/~thocking/">Toby
+href="toby.hocking@nau.edu">Toby
 Dylan Hocking</a> if you are using directlabels or have ideas to
 contribute, thanks!</td>
 

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@ repository</strong></a>. </p>
 <tr>
 
 <td>Please send email to <a
-href="toby.hocking@nau.edu">Toby
+href="http://tdhock.github.io/">Toby
 Dylan Hocking</a> if you are using directlabels or have ideas to
 contribute, thanks!</td>
 


### PR DESCRIPTION
After #39 was pushed, I ran dldoc locally, pushed the changes to my gh-pages branch (those commits are reverted now) and checked to see if the stylesheet was getting linked - was fine for everything under the different plot type directories but for docs/index.html it apparently became `../../../estilo1.css` from `../estilo1.css`: (thanks to the update from templates/head.html)

![css error](https://user-images.githubusercontent.com/30123691/122578774-d77b5c80-d071-11eb-853e-68dfe3dd7186.png)

Sorry for not taking this into account, and also for the directlabels setup code that I updated in docs/index.html but not the same in its template earlier! (I should have made these back in the last PR itself)   

I've fixed these, and for the link to the stylesheet, I'm using the css file hosted onto your GitHub pages (could also use cdn links as an alternative, but note that a normal GitHub link or raw.githubusercontent.com links to the file won't work)