### PR TITLE
do not special case 1 group

### DIFF
--- a/R/utility.function.R
+++ b/R/utility.function.R
@@ -600,12 +600,6 @@ qp.labels <- structure(function# Make a Positioning Method for non-overlapping l
 
   function(d,...){
 
-    ## If there is only 1 label, there is no collision detection to
-    ## do, so just return it.
-    if(nrow(d)==1)return(d)
-
-    ##browser()
-
     ## Reality checks.
     for(v in essential){
       if(! v %in% names(d)){


### PR DESCRIPTION
hi @Anirban166 this PR contains a fix for the following example:
```r
df <- data.frame(i=1:10, label="more
than
one
line
really
a
lot")
library(ggplot2)
gg <- ggplot(df, aes(i, i, color=label))+
  geom_line()
directlabels::direct.label(gg, "right.polygons")
```
When you run this code on master, the label text will be unreadable (going off the top of the plotting region).
Can you please add a test case for this sometime before the end of the summer?
The test case should basically say, the top of the polygon / text grobs should be at or below the top of the plotting region.
Does that make sense?