### PR TITLE
Update index

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 
 <body class="normal">
 
-<h1>Easily add direct labels to plots using the directlabels package</h1>
+<h1>Easily add direct labels to plots using the directlabels package!</h1>
 
 <table>
 <tr>
@@ -29,16 +29,14 @@ high-level plotting systems such as lattice and ggplot2. The main
 function that the package provides is <tt>direct.label(p)</tt>, which
 takes a lattice or ggplot2 plot <tt>p</tt> and adds direct labels:</p>
 
-
 <pre>
-install.packages("directlabels", repo="http://r-forge.r-project.org")
+install.packages("directlabels")
 library(lattice)
 library(directlabels)
 direct.label(xyplot(jitter(Sepal.Length)~jitter(Petal.Length),iris,groups=Species))
-    </pre>
-<p>
-directlabels website navigation:
-</p>
+</pre>
+
+<h2>directlabels website navigation</h2>
 
 <ul>
 <li><a href="docs/index.html">Positioning Method examples database</a></li>


### PR DESCRIPTION
A few minor updates to https://tdhock.github.io/directlabels/ (last!), including updation of the installation command (iris grid example) at the beginning (I just stumbled upon https://stackoverflow.com/questions/60748325/r-ggplot2-directlabels-package-generating-errors-even-with-given-example-code and realized this change was much needed - I'll post an answer there to not use the rforge version after this gets merged)

@tdhock Please change the link to https://tdhock.github.io/directlabels/ in this GitHub repository's 'About section' (website link) from the current http://directlabels.r-forge.r-project.org/ and merge this if it is okay!  