### PR TITLE
Setup code coverage (codecov) and automate the process

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@ revdep
 ^\.travis\.yml$
 ^README\.org$
 build.sh
+^codecov\.yml$

--- a/.github/workflows/Test_coverage.yml
+++ b/.github/workflows/Test_coverage.yml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+name: test-coverage
+
+jobs:
+  test-coverage:
+    runs-on: macOS-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-r@v1
+
+      - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Restore R package cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          install.packages(c("remotes"))
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("covr")
+        shell: Rscript {0}
+
+      - name: Test coverage
+        run: covr::codecov()
+        shell: Rscript {0}

--- a/.github/workflows/Test_coverage.yml
+++ b/.github/workflows/Test_coverage.yml
@@ -42,5 +42,5 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov()
+        run: covr::codecov(token = "${{ secrets.CODECOV_SECRET }}")
         shell: Rscript {0}

--- a/.github/workflows/Test_coverage.yml
+++ b/.github/workflows/Test_coverage.yml
@@ -1,14 +1,12 @@
+name: Test coverage
+
 on:
   push:
     branches:
-      - main
       - master
   pull_request:
     branches:
-      - main
       - master
-
-name: test-coverage
 
 jobs:
   test-coverage:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,15 +14,23 @@ Description: An extensible framework
  and inferring an appropriate Positioning Method.
 URL: https://github.com/tdhock/directlabels
 LazyData: true
-Suggests: MASS,
-	  knitr, markdown,
-	  inlinedocs,
-	  RColorBrewer,
-	  ggplot2 (>= 2.0), rlang,
-	  lattice, alphahull, nlme,
-	  lars, latticeExtra,
-	  dplyr, ggthemes,
-	  testthat
+Suggests: 
+    MASS,
+    knitr,
+    markdown,
+    inlinedocs,
+    RColorBrewer,
+    ggplot2 (>= 2.0),
+    rlang,
+    lattice,
+    alphahull,
+    nlme,
+    lars,
+    latticeExtra,
+    dplyr,
+    ggthemes,
+    testthat,
+    covr
 Imports: grid, quadprog
 Collate: utility.function.R compare.R dotplot.R lineplot.R
 	 densityplot.R ggplot2.R positioning.functions.R

--- a/README.org
+++ b/README.org
@@ -1,4 +1,4 @@
-[[https://travis-ci.org/tdhock/directlabels][https://api.travis-ci.org/tdhock/directlabels.svg?branch=master]]
+[[https://travis-ci.org/tdhock/directlabels][https://api.travis-ci.org/tdhock/directlabels.svg?branch=master]] [![Codecov test coverage](https://codecov.io/gh/tdhock/directlabels/branch/master/graph/badge.svg)](https://codecov.io/gh/tdhock/directlabels?branch=master)
 
 ** Installation from CRAN
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 comment: false
+language: R
+sudo: false
+cache: packages
+after_success:
+Rscript -e 'covr::codecov()'
 
 coverage:
   status:


### PR DESCRIPTION
Hi @tdhock I've set up the required files and generated a codecov token for directlabels using my GitHub account.

Please add a new repository level secret (Settings > Secrets > New repository secret) and for the value field therein, paste the codecov token (I don't have access to secrets or the settings tab). I'll send you mine by email now, and alternatively you can log onto codecov using your GitHub account and generate a token for directlabels and emplace that value instead. Let me know the name you gave for it (so I can use that in my workflow [here](https://github.com/tdhock/directlabels/pull/45/files#diff-88a47ccb00ebafda6800bca90f259b5c45b2c7fb2ed34729c364de9cf6aa5522), similar to [this](https://github.com/Anirban166/Dmc5/blob/1a727ae136a67a3aa41282192713f07cfb9f07de/.github/workflows/test-coverage.yaml#L45)) 