### PR TITLE
Update `legends2hide()`

### DIFF
--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -195,6 +195,22 @@ pkgFun <- function(fun, pkg="ggplot2") {
 ### Extract guides to hide from a ggplot.
 legends2hide <- function(p){
   plistextra <- ggplot2::ggplot_build(p)
+
+  if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
+    # Using clunky get here to avoid R cmd check warnings in earlier versions
+    # of ggplot2
+    get_guide_data <- get("get_guide_data", envir = asNamespace("ggplot2"))
+    for (aes in c("colour", "fill"))  {
+      guide_data <- get_guide_data(plistextra, aes)
+      if (!is.null(guide_data)) {
+        hide <- colnames(guide_data)
+        hide <- hide[!grepl("^\\.", hide)]
+        return(list(colour = aes, hide = hide, data = guide_data))
+      }
+    }
+    return()
+  }
+
   plot <- plistextra$plot
   scales = plot$scales
   layers = plot$layers


### PR DESCRIPTION
Hi Toby,

We have been preparing for a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break directlabels.

This PR updates the `legends2hide()` function to deal with the updated guide system in the new ggplot2 version. It uses the new `get_guide_data()` function to avoid having to reconstitute a good chunk of the guide building code manually.
I'm not 100% sure that it is giving the output that directlabels expects, so I recommend testing this out for yourself with the release candidate to see if it is correct. At the very least, it should stop test failures.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help directlabels get out a fix if necessary.